### PR TITLE
feat: refactor product domain and implement product use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,194 @@
+# Clean Architecture TypeScript Project
+
+Este projeto implementa um sistema completo seguindo os princípios de **Clean Architecture** (Arquitetura Limpa) usando TypeScript, com foco em domínios de **Customer** e **Product**.
+
+## 📋 Descrição do Projeto
+
+O projeto demonstra a implementação de uma arquitetura limpa com separação clara de responsabilidades, seguindo os princípios de Domain-Driven Design (DDD) e práticas de desenvolvimento orientado a testes (TDD).
+
+## 🏗️ Estrutura da Arquitetura
+
+```
+src/
+├── domain/           # Camada de Domínio
+│   ├── @shared/      # Componentes compartilhados
+│   ├── customer/     # Domínio do Cliente
+│   └── product/      # Domínio do Produto
+├── infrastructure/   # Camada de Infraestrutura
+│   ├── api/          # API REST com Express
+│   ├── customer/     # Repositórios de Cliente
+│   └── product/      # Repositórios de Produto
+└── usecase/          # Camada de Casos de Uso
+    ├── customer/     # Casos de uso de Cliente
+    └── product/      # Casos de uso de Produto
+```
+
+## 🎯 Funcionalidades Implementadas
+
+### Customer (Cliente)
+- ✅ Criar cliente
+- ✅ Buscar cliente por ID
+- ✅ Listar todos os clientes
+- ✅ Atualizar dados do cliente
+- ✅ Sistema de pontos de recompensa
+- ✅ Validação de endereço
+
+### Product (Produto)
+- ✅ Criar produto
+- ✅ Buscar produto por ID
+- ✅ Listar todos os produtos
+- ✅ Atualizar dados do produto
+- ✅ Validação de preço e nome
+- ✅ Factory pattern para diferentes tipos de produto
+
+## 🛠️ Tecnologias Utilizadas
+
+- **TypeScript** - Linguagem principal
+- **Node.js** - Runtime
+- **Express.js** - Framework web
+- **Sequelize** - ORM para banco de dados
+- **SQLite** - Banco de dados (em memória para testes)
+- **Jest** - Framework de testes
+- **SWC** - Compilador rápido para TypeScript
+- **Yup** - Validação de esquemas
+- **UUID** - Geração de identificadores únicos
+
+## 📦 Instalação e Configuração
+
+```bash
+# Clone o repositório
+git clone <repository-url>
+cd fc-clean-architecture
+
+# Instale as dependências
+npm install
+
+# Execute os testes
+npm test
+
+# Execute o servidor de desenvolvimento
+npm run dev
+```
+
+## 🧪 Testes
+
+O projeto possui cobertura completa de testes:
+
+- **Testes Unitários**: Para entidades, casos de uso e serviços
+- **Testes de Integração**: Para repositórios com banco de dados
+- **Testes E2E**: Para APIs REST completas
+
+```bash
+# Executar todos os testes
+npm test
+
+# Executar testes específicos
+npm test -- customer
+npm test -- product
+```
+
+## 🌐 API Endpoints
+
+### Customer Endpoints
+```
+POST   /customer     # Criar cliente
+GET    /customer     # Listar clientes (JSON/XML)
+```
+
+### Product Endpoints
+```
+POST   /product      # Criar produto
+GET    /product      # Listar produtos (JSON/XML)
+```
+
+## 📐 Padrões de Design Implementados
+
+- **Factory Pattern**: Criação de entidades
+- **Repository Pattern**: Abstração de acesso a dados
+- **Observer Pattern**: Sistema de eventos de domínio
+- **Notification Pattern**: Coleta de erros de validação
+- **Use Case Pattern**: Lógica de aplicação isolada
+
+## 🎨 Princípios Seguidos
+
+### Clean Architecture
+- **Independência de Frameworks**: Domínio não depende de frameworks externos
+- **Testabilidade**: Todas as camadas são testáveis independentemente
+- **Independência de UI**: Lógica não está acoplada à interface
+- **Independência de Banco**: Domínio não conhece detalhes de persistência
+
+### SOLID Principles
+- **S**ingle Responsibility Principle
+- **O**pen/Closed Principle
+- **L**iskov Substitution Principle
+- **I**nterface Segregation Principle
+- **D**ependency Inversion Principle
+
+## 🔍 Destaques Técnicos
+
+### Sistema de Notificações
+- Coleta de múltiplos erros de validação
+- Contexto específico para cada tipo de erro
+- Propagação controlada de erros
+
+### Event System
+- Eventos de domínio desacoplados
+- Handlers específicos para cada evento
+- Sistema de dispatcher centralizado
+
+### Validation Strategy
+- Validação usando Yup
+- Factory pattern para validators
+- Validação em tempo de construção
+
+## 📝 Exemplos de Uso
+
+### Criar um Cliente
+```bash
+curl -X POST http://localhost:3000/customer \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "John Doe",
+    "address": {
+      "street": "Main St",
+      "number": 123,
+      "zip": "12345",
+      "city": "New York"
+    }
+  }'
+```
+
+### Criar um Produto
+```bash
+curl -X POST http://localhost:3000/product \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Product A",
+    "price": 29.99
+  }'
+```
+
+## 🤝 Contribuição
+
+Este projeto foi desenvolvido como parte de um desafio de arquitetura limpa, demonstrando:
+
+- Separação clara de responsabilidades
+- Testabilidade em todas as camadas
+- Flexibilidade para mudanças
+- Manutenibilidade do código
+- Princípios de design sólidos
+
+## 📚 Conceitos Demonstrados
+
+- **Domain-Driven Design (DDD)**
+- **Test-Driven Development (TDD)**
+- **Clean Architecture**
+- **SOLID Principles**
+- **Design Patterns**
+- **Event-Driven Architecture**
+- **API RESTful**
+- **Object-Relational Mapping (ORM)**
+
+---
+
+*Este projeto serve como referência para implementação de arquitetura limpa em aplicações TypeScript, demonstrando boas práticas de desenvolvimento e organização

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "aluno",
+  "name": "fc-clean-architecture",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/domain/customer/event/address-updated.event.ts
+++ b/src/domain/customer/event/address-updated.event.ts
@@ -1,0 +1,15 @@
+import EventInterface from "../../@shared/event/event.interface";
+
+export default class AddressUpdatedEvent implements EventInterface {
+  dataTimeOccurred: Date;
+  eventData: {
+    id: string;
+    name: string;
+    address: string;
+  };
+
+  constructor(eventData: any) {
+    this.dataTimeOccurred = new Date();
+    this.eventData = eventData;
+  }
+}

--- a/src/domain/customer/event/customer-created.event.ts
+++ b/src/domain/customer/event/customer-created.event.ts
@@ -1,0 +1,11 @@
+import EventInterface from "../../@shared/event/event.interface";
+
+export default class CustomerCreatedEvent implements EventInterface {
+  dataTimeOccurred: Date;
+  eventData: any;
+
+  constructor(eventData: any) {
+    this.dataTimeOccurred = new Date();
+    this.eventData = eventData;
+  }
+}

--- a/src/domain/customer/event/customer_event-dispatcher.spec.ts
+++ b/src/domain/customer/event/customer_event-dispatcher.spec.ts
@@ -1,0 +1,62 @@
+import EventDispatcher from "../../@shared/event/event-dispatcher";
+import AddressUpdatedEvent from "./address-updated.event";
+import CustomerCreatedEvent from "./customer-created.event";
+import SendLogOneHandler from "./handler/send-log-one.handler";
+import SendLogTwoHandler from "./handler/send-log-two.handler";
+import SendLogHandler from "./handler/send-log.handler";
+
+describe("Customer events tests", () => {
+  it("should notify CustomerCreatedEvent handlers", () => {
+    const eventDispatcher = new EventDispatcher();
+
+    const sendLogOneHandler = new SendLogOneHandler();
+    const sendLogTwoHandler = new SendLogTwoHandler();
+
+    const spySendLogOneHandler = jest.spyOn(sendLogOneHandler, "handle");
+    const spySendLogTwoHandler = jest.spyOn(sendLogTwoHandler, "handle");
+
+    eventDispatcher.register("CustomerCreatedEvent", sendLogOneHandler);
+    eventDispatcher.register("CustomerCreatedEvent", sendLogTwoHandler);
+
+    expect(eventDispatcher.getEventHandlers["CustomerCreatedEvent"][0]).toMatchObject(sendLogOneHandler);
+    expect(eventDispatcher.getEventHandlers["CustomerCreatedEvent"][1]).toMatchObject(sendLogTwoHandler);
+
+    const productCreatedEvent = new CustomerCreatedEvent({
+      id: "1",
+      name: "John Doe",
+      street: "Street",
+      number: 123,
+      zipcode: "zip",
+      city: "City",
+      active: true,
+      rewardPoints: 10,
+    });
+
+    eventDispatcher.notify(productCreatedEvent);
+
+    expect(sendLogOneHandler.handle).toHaveBeenCalledWith(productCreatedEvent);
+    expect(sendLogTwoHandler.handle).toHaveBeenCalledWith(productCreatedEvent);
+    expect(spySendLogOneHandler).toHaveBeenCalled();
+    expect(spySendLogTwoHandler).toHaveBeenCalled();
+  });
+
+  it("should notify AddressUpdatedEvent handlers", () => {
+    const eventDispatcher = new EventDispatcher();
+    const sendLogHandler = new SendLogHandler();
+
+    const spySendLogHandler = jest.spyOn(sendLogHandler, "handle");
+    eventDispatcher.register("AddressUpdatedEvent", sendLogHandler);
+
+    expect(eventDispatcher.getEventHandlers["AddressUpdatedEvent"][0]).toMatchObject(sendLogHandler);
+
+    const addressUpdatedEvent = new AddressUpdatedEvent({
+      id: "1",
+      name: "John Doe",
+      address: "Street, 321, Zip, City",
+    });
+
+    eventDispatcher.notify(addressUpdatedEvent);
+    expect(sendLogHandler.handle).toHaveBeenCalledWith(addressUpdatedEvent);
+    expect(spySendLogHandler).toHaveBeenCalled();
+  });
+});

--- a/src/domain/customer/event/handler/send-log-one.handler.ts
+++ b/src/domain/customer/event/handler/send-log-one.handler.ts
@@ -1,0 +1,9 @@
+import EventHandlerInterface from "../../../@shared/event/event-handler.interface";
+import CustomerCreatedEvent from "../customer-created.event";
+
+export default class SendLogOneHandler
+  implements EventHandlerInterface<CustomerCreatedEvent> {
+  handle(event: CustomerCreatedEvent): void {
+    console.log(`Esse é o primeiro console.log do evento: CustomerCreated`);
+  }
+}

--- a/src/domain/customer/event/handler/send-log-two.handler.ts
+++ b/src/domain/customer/event/handler/send-log-two.handler.ts
@@ -1,0 +1,9 @@
+import EventHandlerInterface from "../../../@shared/event/event-handler.interface";
+import CustomerCreatedEvent from "../customer-created.event";
+
+export default class SendLogTwoHandler
+  implements EventHandlerInterface<CustomerCreatedEvent> {
+  handle(event: CustomerCreatedEvent): void {
+    console.log(`Esse é o segundo console.log do evento: CustomerCreated`);
+  }
+}

--- a/src/domain/customer/event/handler/send-log.handler.ts
+++ b/src/domain/customer/event/handler/send-log.handler.ts
@@ -1,0 +1,11 @@
+import EventHandlerInterface from "../../../@shared/event/event-handler.interface";
+import AddressUpdatedEvent from "../address-updated.event";
+
+export default class SendLogHandler
+  implements EventHandlerInterface<AddressUpdatedEvent> {
+  handle(event: AddressUpdatedEvent): void {
+    console.log(`Endereço do cliente: ${event.eventData.id}, 
+                        ${event.eventData.name} alterado para: 
+                        ${event.eventData.address}`);
+  }
+}

--- a/src/domain/product/entity/product-b.ts
+++ b/src/domain/product/entity/product-b.ts
@@ -1,15 +1,20 @@
+import Entity from "../../@shared/entity/entity.abstract";
+import NotificationError from "../../@shared/notification/notification.error";
 import ProductInterface from "./product.interface";
 
-export default class ProductB implements ProductInterface {
-  private _id: string;
+export default class ProductB extends Entity implements ProductInterface {
   private _name: string;
   private _price: number;
 
   constructor(id: string, name: string, price: number) {
+    super();
     this._id = id;
     this._name = name;
     this._price = price;
     this.validate();
+    if (this.notification.hasErrors()) {
+      throw new NotificationError(this.notification.getErrors());
+    }
   }
 
   get id(): string {
@@ -36,13 +41,13 @@ export default class ProductB implements ProductInterface {
 
   validate(): boolean {
     if (this._id.length === 0) {
-      throw new Error("Id is required");
+      this.notification.addError({ context: "product", message: "Id is required" });
     }
     if (this._name.length === 0) {
-      throw new Error("Name is required");
+      this.notification.addError({ context: "product", message: "Name is required" });
     }
     if (this._price < 0) {
-      throw new Error("Price must be greater than zero");
+      this.notification.addError({ context: "product", message: "Price must be greater than zero" });
     }
     return true;
   }

--- a/src/domain/product/entity/product.ts
+++ b/src/domain/product/entity/product.ts
@@ -1,21 +1,27 @@
+import Entity from "../../@shared/entity/entity.abstract";
+import NotificationError from "../../@shared/notification/notification.error";
+import ProductValidatorFactory from "../factory/product.validator.factory";
 import ProductInterface from "./product.interface";
 
-export default class Product implements ProductInterface {
-  private _id: string;
+export default class Product extends Entity implements ProductInterface {
   private _name: string;
   private _price: number;
 
   constructor(id: string, name: string, price: number) {
+    super();
     this._id = id;
     this._name = name;
     this._price = price;
     this.validate();
+    if (this.notification.hasErrors()) {
+      throw new NotificationError(this.notification.getErrors());
+    }
   }
 
   get id(): string {
     return this._id;
   }
-  
+
   get name(): string {
     return this._name;
   }
@@ -34,16 +40,7 @@ export default class Product implements ProductInterface {
     this.validate();
   }
 
-  validate(): boolean {
-    if (this._id.length === 0) {
-      throw new Error("Id is required");
-    }
-    if (this._name.length === 0) {
-      throw new Error("Name is required");
-    }
-    if (this._price < 0) {
-      throw new Error("Price must be greater than zero");
-    }
-    return true;
+  validate() {
+    ProductValidatorFactory.create().validate(this);
   }
 }

--- a/src/domain/product/factory/product.factory.ts
+++ b/src/domain/product/factory/product.factory.ts
@@ -18,4 +18,11 @@ export default class ProductFactory {
         throw new Error("Product type not supported");
     }
   }
+
+  public static createNewProduct(name: string, price: number): Product {
+    return new Product(uuid(), name, price);
+  }
+  public static createNewProductWithId(id: string, name: string, price: number): Product {
+    return new Product(id, name, price);
+  }
 }

--- a/src/domain/product/factory/product.validator.factory.ts
+++ b/src/domain/product/factory/product.validator.factory.ts
@@ -1,0 +1,9 @@
+import ValidatorInterface from "../../@shared/validator/validator.interface";
+import Product from "../entity/product";
+import ProductYupValidator from "../validator/product.yup.validator";
+
+export default class ProductValidatorFactory {
+  static create(): ValidatorInterface<Product> {
+    return new ProductYupValidator();
+  }
+}

--- a/src/domain/product/validator/product.yup.validator.ts
+++ b/src/domain/product/validator/product.yup.validator.ts
@@ -1,0 +1,37 @@
+import ValidatorInterface from "../../@shared/validator/validator.interface";
+import * as yup from "yup";
+import Product from "../entity/product";
+
+export default class ProductYupValidator
+  implements ValidatorInterface<Product>
+{
+  validate(entity: Product): void {
+    try {
+      yup
+        .object()
+        .shape({
+          id: yup.string().required("Id is required"),
+          name: yup.string().required("Name is required"),
+          price: yup.number().moreThan(0,"Price must be greater than zero")
+        })
+        .validateSync(
+          {
+            id: entity.id,
+            name: entity.name,
+            price: entity.price
+          },
+          {
+            abortEarly: false,
+          }
+        );
+    } catch (errors) {
+      const e = errors as yup.ValidationError;
+      e.errors.forEach((error) => {
+        entity.notification.addError({
+          context: "product",
+          message: error,
+        });
+      });
+    }
+  }
+}

--- a/src/infrastructure/api/__tests__/product.e2e.spec.ts
+++ b/src/infrastructure/api/__tests__/product.e2e.spec.ts
@@ -1,0 +1,79 @@
+import { app, sequelize } from "../express";
+import request from "supertest";
+
+describe("E2E test for product", () => {
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+  });
+
+  it("should create a product", async () => {
+    const response = await request(app)
+      .post("/product")
+      .send({
+        name: "Product A",
+        price: 10
+      });
+    expect(response.status).toBe(200);
+    expect(response.body.name).toBe("Product A");
+    expect(response.body.price).toBe(10);
+  });
+
+  it("should not create a product", async () => {
+    const response = await request(app).post("/product").send({
+      name: "Product B",
+    });
+    expect(response.status).toBe(500);
+  });
+
+  it("should list all product", async () => {
+    const response = await request(app)
+      .post("/product")
+      .send({
+        name: "Product A",
+        price: 10
+      });
+    expect(response.status).toBe(200);
+    const response2 = await request(app)
+      .post("/product")
+      .send({
+        name: "Product B",
+        price: 20
+      });
+    expect(response2.status).toBe(200);
+
+    const listResponse = await request(app).get("/product").send();
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.products.length).toBe(2);
+
+    const productA = listResponse.body.products[0];
+    expect(productA.name).toBe("Product A");
+    expect(productA.price).toBe(10);
+
+    const productB = listResponse.body.products[1];
+    expect(productB.name).toBe("Product B");
+    expect(productB.price).toBe(20);
+
+    const listResponseXML = await request(app)
+      .get("/product")
+      .set("Accept", "application/xml")
+      .send();
+
+    expect(listResponseXML.status).toBe(200);
+    expect(listResponseXML.text).toContain(`<?xml version="1.0" encoding="UTF-8"?>`);
+    expect(listResponseXML.text).toContain(`<products>`);
+    expect(listResponseXML.text).toContain(`<product>`);
+    expect(listResponseXML.text).toContain(`<name>Product A</name>`);
+    expect(listResponseXML.text).toContain(`<price>10</price>`);
+    expect(listResponseXML.text).toContain(`</product>`);
+    expect(listResponseXML.text).toContain(`<product>`);
+    expect(listResponseXML.text).toContain(`<name>Product B</name>`);
+    expect(listResponseXML.text).toContain(`<price>20</price>`);
+    expect(listResponseXML.text).toContain(`</product>`);
+    expect(listResponseXML.text).toContain(`</products>`);
+  });
+});

--- a/src/infrastructure/api/express.ts
+++ b/src/infrastructure/api/express.ts
@@ -1,11 +1,14 @@
 import express, { Express } from "express";
 import { Sequelize } from "sequelize-typescript";
-import CustomerModel from "../customer/repository/sequelize/customer.model";
 import { customerRoute } from "./routes/customer.route";
+import { productRoute } from "./routes/product.route";
+import CustomerModel from "../customer/repository/sequelize/customer.model";
+import ProductModel from "../product/repository/sequelize/product.model";
 
 export const app: Express = express();
 app.use(express.json());
 app.use("/customer", customerRoute);
+app.use("/product", productRoute);
 
 export let sequelize: Sequelize;
 
@@ -16,6 +19,7 @@ async function setupDb() {
     logging: false,
   });
   await sequelize.addModels([CustomerModel]);
+  await sequelize.addModels([ProductModel]);
   await sequelize.sync();
 }
 setupDb();

--- a/src/infrastructure/api/presenters/product.presenter.ts
+++ b/src/infrastructure/api/presenters/product.presenter.ts
@@ -1,0 +1,26 @@
+import { toXML } from "jstoxml";
+import { OutputListProductDto } from "../../../usecase/product/list/list.product.dto";
+
+export default class ProductPresenter {
+  static listXML(data: OutputListProductDto): string {
+    const xmlOption = {
+      header: true,
+      indent: "  ",
+      newline: "\n",
+      allowEmpty: true,
+    };
+
+    return toXML(
+      {
+        products: {
+          product: data.products.map((product: { id: string; name: string; price: number }) => ({
+            id: product.id,
+            name: product.name,
+            price: product.price
+          })),
+        },
+      },
+      xmlOption
+    );
+  }
+}

--- a/src/infrastructure/api/routes/product.route.ts
+++ b/src/infrastructure/api/routes/product.route.ts
@@ -1,0 +1,31 @@
+import express, { Request, Response } from "express";
+import CreateProductUseCase from "../../../usecase/product/create/create.customer.usecase";
+import ProductRepository from "../../product/repository/sequelize/product.repository";
+import ListProductUseCase from "../../../usecase/product/list/list.product.usecase";
+import ProductPresenter from "../presenters/product.presenter";
+
+export const productRoute = express.Router();
+
+productRoute.post("/", async (req: Request, res: Response) => {
+  const usecase = new CreateProductUseCase(new ProductRepository());
+  try {
+    const productDto = {
+      name: req.body.name,
+      price: req.body.price
+    };
+    const output = await usecase.execute(productDto);
+    res.send(output);
+  } catch (err) {
+    res.status(500).send(err);
+  }
+});
+
+productRoute.get("/", async (req: Request, res: Response) => {
+  const usecase = new ListProductUseCase(new ProductRepository());
+  const output = await usecase.execute({});
+
+  res.format({
+    json: async () => res.send(output),
+    xml: async () => res.send(ProductPresenter.listXML(output)),
+  });
+});

--- a/src/usecase/product/create/create.customer.unit.spec.ts
+++ b/src/usecase/product/create/create.customer.unit.spec.ts
@@ -1,0 +1,49 @@
+import CreateProductUseCase from "./create.customer.usecase";
+import { InputCreateProductDto } from "./create.product.dto";
+
+const input : InputCreateProductDto = {
+  name: "Product A",
+  price: 10
+};
+
+const MockRepository = () => {
+  return {
+    find: jest.fn(),
+    findAll: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  };
+};
+
+describe("Unit test create product use case", () => {
+  it("should create a product", async () => {
+    const productRepository = MockRepository();
+    const productCreateUseCase = new CreateProductUseCase(productRepository);
+
+    const output = await productCreateUseCase.execute(input);
+
+    expect(output).toEqual({
+      id: expect.any(String),
+      name: input.name,
+      price: input.price
+    });
+  });
+
+  it("should thrown an error when name is missing", async () => {
+    const customerRepository = MockRepository();
+    const customerCreateUseCase = new CreateProductUseCase(customerRepository);
+
+    input.name = "";
+
+    await expect(customerCreateUseCase.execute(input)).rejects.toThrow("Name is required");
+  });
+
+  it("should thrown an error when price is missing", async () => {
+    const customerRepository = MockRepository();
+    const customerCreateUseCase = new CreateProductUseCase(customerRepository);
+    input.name = "Product A";
+    input.price = -1;
+
+    await expect(customerCreateUseCase.execute(input)).rejects.toThrow("Price must be greater than zero");
+  });
+});

--- a/src/usecase/product/create/create.customer.usecase.ts
+++ b/src/usecase/product/create/create.customer.usecase.ts
@@ -1,0 +1,28 @@
+import {
+  InputCreateProductDto,
+  OutputCreateProductDto,
+} from "./create.product.dto";
+import { v4 as uuid } from "uuid";
+import ProductFactory from "../../../domain/product/factory/product.factory";
+import ProductRepositoryInterface from "../../../domain/product/repository/product-repository.interface";
+
+export default class CreateProductUseCase {
+  private productRepository: ProductRepositoryInterface;
+
+  constructor(productRepository: ProductRepositoryInterface) {
+    this.productRepository = productRepository;
+  }
+
+  async execute(input: InputCreateProductDto): Promise<OutputCreateProductDto>
+  {
+    const product = ProductFactory.createNewProduct(input.name,input.price);
+
+    await this.productRepository.create(product);
+
+    return {
+      id: product.id,
+      name: product.name,
+      price: product.price
+    };
+  }
+}

--- a/src/usecase/product/create/create.product.dto.ts
+++ b/src/usecase/product/create/create.product.dto.ts
@@ -1,0 +1,10 @@
+export interface InputCreateProductDto {
+  name: string;
+  price: number;
+}
+
+export interface OutputCreateProductDto {
+  id: string;
+  name: string;
+  price: number;
+}

--- a/src/usecase/product/find/find.product.dto.ts
+++ b/src/usecase/product/find/find.product.dto.ts
@@ -1,0 +1,9 @@
+export interface InputFindProductDto {
+  id: string;
+}
+
+export interface OutputFindProductDto {
+  id: string;
+  name: string;
+  price : number;
+}

--- a/src/usecase/product/find/find.product.unit.spec.ts
+++ b/src/usecase/product/find/find.product.unit.spec.ts
@@ -1,0 +1,51 @@
+import ProductFactory from "../../../domain/product/factory/product.factory";
+import { InputFindProductDto, OutputFindProductDto } from "./find.product.dto";
+import FindProductUseCase from "./find.product.usecase";
+
+const customer = ProductFactory.createNewProductWithId("123","Product A", 10);
+
+const MockRepository = () => {
+  return {
+    find: jest.fn().mockReturnValue(Promise.resolve(customer)),
+    findAll: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  };
+};
+
+describe("Unit Test find product use case", () => {
+  it("should find a product", async () => {
+    const productRepository = MockRepository();
+    const usecase = new FindProductUseCase(productRepository);
+
+    const input : InputFindProductDto = {
+      id: "123",
+    };
+
+    const output: OutputFindProductDto = {
+      id: "123",
+      name: "Product A",
+      price: 10,
+    };
+
+    const result = await usecase.execute(input);
+
+    expect(result).toEqual(output);
+  });
+
+  it("should not find a product", async () => {
+    const productRepository = MockRepository();
+    productRepository.find.mockImplementation(() => {
+      throw new Error("Product not found");
+    });
+    const usecase = new FindProductUseCase(productRepository);
+
+    const input : InputFindProductDto = {
+      id: "123",
+    };
+
+    expect(() => {
+      return usecase.execute(input);
+    }).rejects.toThrow("Product not found");
+  });
+});

--- a/src/usecase/product/find/find.product.usecase.ts
+++ b/src/usecase/product/find/find.product.usecase.ts
@@ -1,0 +1,23 @@
+import ProductRepositoryInterface from "../../../domain/product/repository/product-repository.interface";
+import {
+  InputFindProductDto,
+  OutputFindProductDto,
+} from "./find.product.dto";
+
+export default class FindProductUseCase {
+  private _productRepository: ProductRepositoryInterface;
+
+  constructor(productRepository: ProductRepositoryInterface) {
+    this._productRepository = productRepository;
+  }
+
+  async execute(input: InputFindProductDto): Promise<OutputFindProductDto> {
+    const product = await this._productRepository.find(input.id);
+
+    return {
+      id: product.id,
+      name: product.name,
+      price: product.price,
+    };
+  }
+}

--- a/src/usecase/product/list/list.product.dto.ts
+++ b/src/usecase/product/list/list.product.dto.ts
@@ -1,0 +1,11 @@
+export interface InputListProductDto {}
+
+type Product = {
+  id: string;
+  name: string;
+  price: number;
+};
+
+export interface OutputListProductDto {
+  products: Product[];
+}

--- a/src/usecase/product/list/list.product.unit.spec.ts
+++ b/src/usecase/product/list/list.product.unit.spec.ts
@@ -1,0 +1,33 @@
+import ProductFactory from "../../../domain/product/factory/product.factory";
+import ListProductUseCase from "./list.product.usecase";
+
+const product1 = ProductFactory.createNewProductWithId("123","Product A",10);
+
+const product2 = ProductFactory.createNewProductWithId("124","Product B",20);
+
+const MockRepository = () => {
+  return {
+    create: jest.fn(),
+    find: jest.fn(),
+    update: jest.fn(),
+    findAll: jest.fn().mockReturnValue(Promise.resolve([product1, product2])),
+  };
+};
+
+describe("Unit test for listing products use case", () => {
+  it("should list a products", async () => {
+    const repository = MockRepository();
+    const useCase = new ListProductUseCase(repository);
+
+    const output = await useCase.execute({});
+
+    expect(output.products.length).toBe(2);
+    expect(output.products[0].id).toBe(product1.id);
+    expect(output.products[0].name).toBe(product1.name);
+    expect(output.products[0].price).toBe(product1.price);
+
+    expect(output.products[1].id).toBe(product2.id);
+    expect(output.products[1].name).toBe(product2.name);
+    expect(output.products[1].price).toBe(product2.price);
+  });
+});

--- a/src/usecase/product/list/list.product.usecase.ts
+++ b/src/usecase/product/list/list.product.usecase.ts
@@ -1,0 +1,30 @@
+import Product from "../../../domain/product/entity/product";
+import ProductRepositoryInterface from "../../../domain/product/repository/product-repository.interface";
+import {
+  InputListProductDto,
+  OutputListProductDto,
+} from "./list.product.dto";
+
+export default class ListProductUseCase {
+  private _productRepository: ProductRepositoryInterface;
+  constructor(productRepository: ProductRepositoryInterface) {
+    this._productRepository = productRepository;
+  }
+
+  async execute(input: InputListProductDto): Promise<OutputListProductDto> {
+    const products = await this._productRepository.findAll();
+    return OutputMapper.toOutput(products);
+  }
+}
+
+class OutputMapper {
+  static toOutput(product: Product[]): OutputListProductDto {
+    return {
+      products: product.map((product) => ({
+        id: product.id,
+        name: product.name,
+        price: product.price
+      })),
+    };
+  }
+}

--- a/src/usecase/product/product.integration.spec.ts
+++ b/src/usecase/product/product.integration.spec.ts
@@ -1,0 +1,165 @@
+import { Sequelize } from "sequelize-typescript";
+import ProductModel from "../../infrastructure/product/repository/sequelize/product.model";
+import ProductRepository from "../../infrastructure/product/repository/sequelize/product.repository";
+import Product from "../../domain/product/entity/product";
+
+describe("Product repository integration test", () => {
+    let sequelize: Sequelize;
+
+    beforeEach(async () => {
+        sequelize = new Sequelize({
+            dialect: "sqlite",
+            storage: ":memory:",
+            logging: false,
+            sync: { force: true },
+        });
+
+        await sequelize.addModels([ProductModel]);
+        await sequelize.sync();
+    });
+
+    afterEach(async () => {
+        await sequelize.close();
+    });
+
+    it("should create a product", async () => {
+        const productRepository = new ProductRepository();
+        const product = new Product("123", "Product 1", 100);
+
+        await productRepository.create(product);
+
+        const productModel = await ProductModel.findOne({
+            where: { id: "123" },
+        });
+
+        expect(productModel.toJSON()).toStrictEqual({
+            id: "123",
+            name: "Product 1",
+            price: 100,
+        });
+    });
+
+    it("should update a product", async () => {
+        const productRepository = new ProductRepository();
+        const product = new Product("123", "Product 1", 100);
+
+        await productRepository.create(product);
+
+        product.changeName("Product 2");
+        product.changePrice(200);
+
+        await productRepository.update(product);
+
+        const productModel = await ProductModel.findOne({
+            where: { id: "123" },
+        });
+
+        expect(productModel.toJSON()).toStrictEqual({
+            id: "123",
+            name: "Product 2",
+            price: 200,
+        });
+    });
+
+    it("should find a product", async () => {
+        const productRepository = new ProductRepository();
+        const product = new Product("123", "Product 1", 100);
+
+        await productRepository.create(product);
+
+        const productResult = await productRepository.find("123");
+
+        expect(product).toStrictEqual(productResult);
+    });
+
+    it("should find all products", async () => {
+        const productRepository = new ProductRepository();
+        const product1 = new Product("123", "Product 1", 100);
+        const product2 = new Product("456", "Product 2", 200);
+
+        await productRepository.create(product1);
+        await productRepository.create(product2);
+
+        const products = await productRepository.findAll();
+
+        expect(products).toHaveLength(2);
+        expect(products).toContainEqual(product1);
+        expect(products).toContainEqual(product2);
+    });
+
+    it("should create multiple products with different prices", async () => {
+        const productRepository = new ProductRepository();
+        const products = [
+            new Product("1", "Product A", 50.99),
+            new Product("2", "Product B", 25.00),
+            new Product("3", "Product C", 199.99),
+        ];
+
+        for (const product of products) {
+            await productRepository.create(product);
+        }
+
+        const allProducts = await productRepository.findAll();
+
+        expect(allProducts).toHaveLength(3);
+        expect(allProducts.map(p => p.price)).toEqual([50.99, 25.00, 199.99]);
+    });
+
+    it("should handle product name changes correctly", async () => {
+        const productRepository = new ProductRepository();
+        const product = new Product("123", "Original Name", 100);
+
+        await productRepository.create(product);
+
+        // Change name multiple times
+        product.changeName("Updated Name");
+        await productRepository.update(product);
+
+        product.changeName("Final Name");
+        await productRepository.update(product);
+
+        const foundProduct = await productRepository.find("123");
+        expect(foundProduct.name).toBe("Final Name");
+    });
+
+    it("should handle price changes correctly", async () => {
+        const productRepository = new ProductRepository();
+        const product = new Product("123", "Test Product", 50);
+
+        await productRepository.create(product);
+
+        // Update price
+        product.changePrice(75.50);
+        await productRepository.update(product);
+
+        const foundProduct = await productRepository.find("123");
+        expect(foundProduct.price).toBe(75.50);
+    });
+
+    it("should maintain data integrity across operations", async () => {
+        const productRepository = new ProductRepository();
+        const product = new Product("123", "Test Product", 100);
+
+        // Create
+        await productRepository.create(product);
+        let foundProduct = await productRepository.find("123");
+        expect(foundProduct.id).toBe("123");
+        expect(foundProduct.name).toBe("Test Product");
+        expect(foundProduct.price).toBe(100);
+
+        // Update
+        product.changeName("Updated Product");
+        product.changePrice(150);
+        await productRepository.update(product);
+
+        foundProduct = await productRepository.find("123");
+        expect(foundProduct.id).toBe("123");
+        expect(foundProduct.name).toBe("Updated Product");
+        expect(foundProduct.price).toBe(150);
+
+        // Verify in findAll
+        const allProducts = await productRepository.findAll();
+        expect(allProducts).toHaveLength(1);
+        expect(allProducts[0]).toEqual(foundProduct);
+    });
+});

--- a/src/usecase/product/update/update.customer.dto.ts
+++ b/src/usecase/product/update/update.customer.dto.ts
@@ -1,0 +1,11 @@
+export interface InputUpdateProductDto {
+    id: string;
+    name: string;
+    price: number;
+}
+
+export interface OutputUpdateProductDto {
+    id: string;
+    name: string;
+    price: number;
+}

--- a/src/usecase/product/update/update.customer.unit.spec.ts
+++ b/src/usecase/product/update/update.customer.unit.spec.ts
@@ -1,0 +1,29 @@
+import ProductFactory from "../../../domain/product/factory/product.factory";
+import UpdateProductUseCase from "./update.customer.usecase";
+const product = ProductFactory.createNewProduct("Product A",10);
+
+const input = {
+  id: product.id,
+  name: "Product AB",
+  price: 10
+};
+
+const MockRepository = () => {
+  return {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    find: jest.fn().mockReturnValue(Promise.resolve(product)),
+    update: jest.fn(),
+  };
+};
+
+describe("Unit test for product update use case", () => {
+  it("should update a product", async () => {
+    const productRepository = MockRepository();
+    const productUpdateUseCase = new UpdateProductUseCase(productRepository);
+
+    const output = await productUpdateUseCase.execute(input);
+
+    expect(output).toEqual(input);
+  });
+});

--- a/src/usecase/product/update/update.customer.usecase.ts
+++ b/src/usecase/product/update/update.customer.usecase.ts
@@ -1,0 +1,25 @@
+import ProductRepositoryInterface from "../../../domain/product/repository/product-repository.interface";
+import {
+  InputUpdateProductDto,
+  OutputUpdateProductDto,
+} from "./update.customer.dto";
+export default class UpdateProductUseCase {
+  private _productRepository: ProductRepositoryInterface;
+  constructor(productRepository: ProductRepositoryInterface) {
+    this._productRepository = productRepository;
+  }
+
+  async execute(input: InputUpdateProductDto): Promise<OutputUpdateProductDto> {
+    const product = await this._productRepository.find(input.id);
+    product.changeName(input.name);
+    product.changePrice(input.price);
+    
+    await this._productRepository.update(product);
+
+    return {
+      id: product.id,
+      name: product.name,
+      price: product.price,
+    };
+  }
+}


### PR DESCRIPTION
- Rename project to "fc-clean-architecture"
- Extend ProductB and Product classes from Entity
- Implement notification system for validation errors in Product classes
- Create ProductValidatorFactory and ProductYupValidator for product validation
- Add product creation and listing use cases with corresponding DTOs
- Implement product repository with Sequelize integration
- Create API routes for product management
- Add end-to-end tests for product API
- Implement event handling for customer events
- Add unit tests for product use cases and integration tests for product repository